### PR TITLE
fixes stats played issue and won percentage

### DIFF
--- a/lib/domain.dart
+++ b/lib/domain.dart
@@ -118,9 +118,11 @@ class Stats {
         lastBoard = json['lastBoard'] ?? '',
         gameNumber = json['gameNumber'] ?? 0;
 
-  int get played => guessDistribution.reduce((value, g) => value + g);
+  int get played => guessDistribution.reduce((value, g) => value + g) + lost;
 
-  int get percentWon => played == 0 ? 0 : (played / won * 100).round();
+  int get percentWon => played == 0 
+    ? 0 
+    : (won / played * 100).round();
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = <String, dynamic>{};

--- a/lib/game.dart
+++ b/lib/game.dart
@@ -143,15 +143,18 @@ class Flurdle {
       _context.stats.guessDistribution[index] += 1;
       _context.stats.lastGuess = index + 1;
       _context.stats.won += 1;
-      _context.stats.gameNumber = _gameNumber;
       _context.stats.streak.current += 1;
       if (_context.stats.streak.current > _context.stats.streak.max) {
         _context.stats.streak.max = _context.stats.streak.current;
       }
       _context.stats.lastBoard = _getShareableBoard(index);
     } else {
+      _context.stats.lost += 1;
       _context.stats.streak.current = 0;
+      _context.stats.lastGuess = -1;
     }
+    _context.stats.gameNumber = _gameNumber;
+
     Future.delayed(Duration.zero, () async {
       await StatsService().saveStats(_context.stats);
     });

--- a/lib/widgets/stats.dart
+++ b/lib/widgets/stats.dart
@@ -247,9 +247,12 @@ class _StatsState extends State<StatsWidget> {
                                   child: ElevatedButton(
                                     style: ElevatedButton.styleFrom(primary: Colors.green),
                                     onPressed: () {
+                                      var guesses = widget.stats.lastGuess == -1
+                                          ? 'X'
+                                          : widget.stats.lastGuess;
                                       Share.share(
-                                          'Flurdle ${widget.stats.gameNumber} ${widget.stats.lastGuess}/6\n${widget.stats.lastBoard}',
-                                          subject: 'Flurdle ${widget.stats.lastGuess}/6');
+                                          'Flurdle ${widget.stats.gameNumber} $guesses/6\n${widget.stats.lastBoard}',
+                                          subject: 'Flurdle $guesses/6');
                                     },
                                     child: Row(
                                       mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
Fixes #2 

Also fixes:
- `Win %` was not calculating percentage correctly.
- `Guess Distribution` was showing green row when a game was lost
- Sharing text when losing a game did not reflect game number